### PR TITLE
Add android Namespace

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" 
+        xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-autostart" 
         version="2.0.0">
 


### PR DESCRIPTION
The proposed change will resolve the issue described in https://github.com/ToniKorin/cordova-plugin-autostart/issues/8. Adding the android namespace will allow VS2015 to correctly load the XML
