### PR TITLE
one possible solution for issue #7

### DIFF
--- a/src/android/AppStarter.java
+++ b/src/android/AppStarter.java
@@ -13,10 +13,6 @@ public class AppStarter {
     public static final int BYPASS_USERPRESENT_MODIFICATION = -1;
     
     public void run(Context context, Intent intent, int componentState) {
-	this.run(context, intent, componentState, false);
-    }
-
-    public void run(Context context, Intent intent, int componentState, boolean bootCompleted) {
         // Enable or Disable UserPresentReceiver (or bypass the modification)
         //Log.d("Cordova AppStarter", "UserPresentReceiver component, new state:" + String.valueOf(componentState));
         if( componentState != BYPASS_USERPRESENT_MODIFICATION ) {
@@ -36,9 +32,7 @@ public class AppStarter {
             serviceIntent.setClassName(context, packageName + "." + className);
             serviceIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             serviceIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-	    if (bootCompleted) {
-              serviceIntent.putExtra("cordova_autostart", true);
-            }
+            serviceIntent.putExtra("cordova_autostart", true);
             context.startActivity(serviceIntent);
         }
     }

--- a/src/android/AppStarter.java
+++ b/src/android/AppStarter.java
@@ -13,7 +13,10 @@ public class AppStarter {
     public static final int BYPASS_USERPRESENT_MODIFICATION = -1;
     
     public void run(Context context, Intent intent, int componentState) {
+	this.run(context, intent, componentState, false);
+    }
 
+    public void run(Context context, Intent intent, int componentState, boolean bootCompleted) {
         // Enable or Disable UserPresentReceiver (or bypass the modification)
         //Log.d("Cordova AppStarter", "UserPresentReceiver component, new state:" + String.valueOf(componentState));
         if( componentState != BYPASS_USERPRESENT_MODIFICATION ) {
@@ -33,6 +36,9 @@ public class AppStarter {
             serviceIntent.setClassName(context, packageName + "." + className);
             serviceIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             serviceIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+	    if (bootCompleted) {
+              serviceIntent.putExtra("cordova_autostart", true);
+            }
             context.startActivity(serviceIntent);
         }
     }

--- a/src/android/AppStarter.java
+++ b/src/android/AppStarter.java
@@ -13,6 +13,10 @@ public class AppStarter {
     public static final int BYPASS_USERPRESENT_MODIFICATION = -1;
     
     public void run(Context context, Intent intent, int componentState) {
+	     this.run(context, intent, componentState, false);
+    }
+
+    public void run(Context context, Intent intent, int componentState, boolean onAutostart) {
         // Enable or Disable UserPresentReceiver (or bypass the modification)
         //Log.d("Cordova AppStarter", "UserPresentReceiver component, new state:" + String.valueOf(componentState));
         if( componentState != BYPASS_USERPRESENT_MODIFICATION ) {
@@ -32,7 +36,9 @@ public class AppStarter {
             serviceIntent.setClassName(context, packageName + "." + className);
             serviceIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             serviceIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            serviceIntent.putExtra("cordova_autostart", true);
+	          if (onAutostart) {
+              serviceIntent.putExtra("cordova_autostart", true);
+            }
             context.startActivity(serviceIntent);
         }
     }

--- a/src/android/BootCompletedReceiver.java
+++ b/src/android/BootCompletedReceiver.java
@@ -12,6 +12,6 @@ public class BootCompletedReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         
         AppStarter appStarter = new AppStarter();
-        appStarter.run(context, intent, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, true);
+        appStarter.run(context, intent, PackageManager.COMPONENT_ENABLED_STATE_ENABLED);
     }
 }

--- a/src/android/BootCompletedReceiver.java
+++ b/src/android/BootCompletedReceiver.java
@@ -12,6 +12,6 @@ public class BootCompletedReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         
         AppStarter appStarter = new AppStarter();
-        appStarter.run(context, intent, PackageManager.COMPONENT_ENABLED_STATE_ENABLED);
+        appStarter.run(context, intent, PackageManager.COMPONENT_ENABLED_STATE_ENABLED, true);
     }
 }

--- a/src/android/UserPresentReceiver.java
+++ b/src/android/UserPresentReceiver.java
@@ -12,6 +12,6 @@ public class UserPresentReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
     
         AppStarter appStarter = new AppStarter();
-        appStarter.run(context, intent, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+        appStarter.run(context, intent, PackageManager.COMPONENT_ENABLED_STATE_DISABLED, true);
     }
 }


### PR DESCRIPTION
This just puts an `extra` on the intent (`cordova_autostart = true`), if the app has been started after boot.

Then you can use some plugin to access the intent and determine how the app has been launched.

To do so, first install a plugin to read the intent - e.g.:
`cordova plugin add https://github.com/napolitano/cordova-plugin-intent --save`

Then use it to access the intent - e.g.:
```javascript
// It seems, this code can even be run before cordova's deviceready event is triggered:
window.plugins.intent.getCordovaIntent(function(intent) {
   if (intent.extras
        && intent.extras.cordova_autostart) {
     console.log("App has been launched automatically after boot.");
   }
   else {
     console.log("App has been launched manually.");
   }
});
```