### PR TITLE
Enable service auto-start

### DIFF
--- a/src/android/AppStarter.java
+++ b/src/android/AppStarter.java
@@ -1,17 +1,18 @@
 package com.tonikorin.cordova.plugin.autostart;
- 
+
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.SharedPreferences;
 import com.tonikorin.cordova.plugin.autostart.AutoStart;
-//import android.util.Log;
- 
+// import android.util.Log;
+
 public class AppStarter {
 
     public static final int BYPASS_USERPRESENT_MODIFICATION = -1;
-    
+    private static final String CORDOVA_AUTOSTART = "cordova_autostart";
+
     public void run(Context context, Intent intent, int componentState) {
 	     this.run(context, intent, componentState, false);
     }
@@ -22,24 +23,36 @@ public class AppStarter {
         if( componentState != BYPASS_USERPRESENT_MODIFICATION ) {
             ComponentName receiver = new ComponentName(context, UserPresentReceiver.class);
             PackageManager pm = context.getPackageManager();
-            pm.setComponentEnabledSetting(receiver, componentState, PackageManager.DONT_KILL_APP); 
+            pm.setComponentEnabledSetting(receiver, componentState, PackageManager.DONT_KILL_APP);
         }
-    
+
         // Starting your app...
         //Log.d("Cordova AppStarter", "STARTING APP...");
         SharedPreferences sp = context.getSharedPreferences(AutoStart.PREFS, Context.MODE_PRIVATE);
         String packageName = context.getPackageName();
-        String className = sp.getString(AutoStart.CLASS_NAME, "");
-        if( !className.equals("") ){
+        String activityClassName = sp.getString(AutoStart.ACTIVITY_CLASS_NAME, "");
+        if( !activityClassName.equals("") ){
             //Log.d("Cordova AppStarter", className);
-            Intent serviceIntent = new Intent();
-            serviceIntent.setClassName(context, packageName + "." + className);
-            serviceIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            serviceIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            Intent activityIntent = new Intent();
+            activityIntent.setClassName(
+                context, String.format("%s.%s", packageName, activityClassName));
+            activityIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            activityIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             if (onAutostart) {
-              serviceIntent.putExtra("cordova_autostart", true);
+              activityIntent.putExtra(CORDOVA_AUTOSTART, true);
             }
-            context.startActivity(serviceIntent);
+            context.startActivity(activityIntent);
         }
+        // Start a service in the background.
+        String serviceClassName = sp.getString(AutoStart.SERVICE_CLASS_NAME, "");
+        if ( !serviceClassName.equals("") ) {
+            Intent serviceIntent = new Intent();
+            serviceIntent.setClassName(context, serviceClassName);
+            if ( onAutostart ) {
+                serviceIntent.putExtra(CORDOVA_AUTOSTART, true);
+            }
+            context.startService(serviceIntent);
+        }
+
     }
 }

--- a/www/auto-start.js
+++ b/www/auto-start.js
@@ -1,6 +1,6 @@
 /*
     Author: Toni Korin
-	
+
 	Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -22,7 +22,7 @@
 var exec    = require('cordova/exec');
 
 /**
- * Activates the automatic start of your app 
+ * Activates the automatic start of your app
  * after the reboot of the device
  */
 exports.enable = function () {
@@ -30,7 +30,15 @@ exports.enable = function () {
 };
 
 /**
- * Deactivates the automatic start of your app 
+ * Activates the automatic start of an arbitrary (exported) service
+ * after the reboot of the device
+ */
+exports.enableService = function (serviceClassName) {
+    cordova.exec(null, null, 'AutoStart', 'enableService', [serviceClassName]);
+};
+
+/**
+ * Deactivates the automatic start of your app and service
  * after the reboot of the device
  */
 exports.disable = function () {


### PR DESCRIPTION
* Adds a plugin action, `enableService`, that takes an exported service name to be automatically started on boot.
* `disable` prevents both the app and the service from being automatically started.