### PR TITLE
Add macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This [Cordova][cordova] plugin will start automatically your __Android__ app or 
 
 ## Supported Platforms ##
 - __Android__
+- __macOS__
 
 ## Usage ##
 
@@ -10,10 +11,12 @@ This [Cordova][cordova] plugin will start automatically your __Android__ app or 
 ```javascript
 cordova.plugins.autoStart.enable();
 ```
+Not applicable in macOS.
 #### Enable the automatic startup of your service after the boot ####
 ```javascript
 cordova.plugins.autoStart.enableService("yourServiceClassName");
 ```
+In macOS, pass the bundle identifier of a helper application to launch it at startup.
 #### Disable the automatic startup of your app and service after the boot ####
 This is the default action if you have never called the "enable" function.
 ```javascript
@@ -23,9 +26,14 @@ cordova.plugins.autoStart.disable();
 #### Indication of automatic startup ####
 If the automatic startup has occured, the Android intent includes the attribute "cordova_autostart" with value true. See more instructions to utilize it at related plugins.
 
+#### macOS helper application
+Sandboxed macOS applications are not allowed to write arbitrary files, which means that they cannot register themselves as [Launch Agents](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html). Instead, Apple allows the registration of a helper application, embedded in the main app's bundle, to start on boot and launch the main app.
+
+The `enableService` and `disable` actions will register/unregister the helper application to launch on startup. It is the caller's responsibility to implement the helper app. See Apple's [documentation](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLoginItems.html) for more details.
+
 ## Related plugins ##
-- [cordova-plugin-intent][plugin-intent] to check out the "cordova_autostart" from extras of Android intent, if your app has automatically started. See more details from [here][stackoverflow_2]. 
-- [cordova-android-movetasktoback][plugin-movetasktoback] to move your app to background 
+- [cordova-plugin-intent][plugin-intent] to check out the "cordova_autostart" from extras of Android intent, if your app has automatically started. See more details from [here][stackoverflow_2].
+- [cordova-android-movetasktoback][plugin-movetasktoback] to move your app to background
 - [cordova-plugin-background-mode][plugin-background-mode] to keep your app running
 
 ## Installation ##
@@ -61,7 +69,7 @@ Add the following xml line to your config.xml:
 
 ## Remarks ##
 1. Installation to the SD card will prevent the automatic start of your app after the boot. See more details from [here][stackoverflow_1].
-2. During the boot your app may start before it has no network connectivity. Your app have to take care of it e.g. using the cordova-plugin-network-information. 
+2. During the boot your app may start before it has no network connectivity. Your app have to take care of it e.g. using the cordova-plugin-network-information.
 
 ## History ##
 Check the [Change Log][changelog].

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0" 
+<plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="cordova-plugin-autostart" 
+        id="cordova-plugin-autostart"
         version="2.2.0">
 
     <name>Autostart</name>
 
     <description>
-        The application will be automatically started after the every boot and the automatic update of your application. 
+        The application will be automatically started after the every boot and the automatic update of your application.
         You can enable or disable the autostart function in your app.
     </description>
 
@@ -66,6 +66,21 @@
         <source-file src="src/android/PackageReplacedReceiver.java" target-dir="src/com/tonikorin/cordova/plugin/autostart" />
         <source-file src="src/android/AppStarter.java"            	target-dir="src/com/tonikorin/cordova/plugin/autostart" />
         <source-file src="src/android/AutoStart.java"             	target-dir="src/com/tonikorin/cordova/plugin/autostart" />
+    </platform>
+
+    <!-- macOS -->
+    <platform name="osx">
+        <config-file target="config.xml" parent="/*">
+          <feature name="AutoStart">
+            <param name="ios-package" value="AutoStart" />
+            <param name="onload" value="true" />
+          </feature>
+        </config-file>
+
+        <source-file src="src/osx/Autostart.swift" />
+        <framework src="ServiceManagement.framework" />
+
+        <dependency id="cordova-plugin-swift-support" version="~3.1.1"/>
     </platform>
 
 </plugin>

--- a/src/osx/AutoStart.swift
+++ b/src/osx/AutoStart.swift
@@ -1,0 +1,51 @@
+
+import Foundation
+import ServiceManagement
+
+@objcMembers
+class AutoStart: CDVPlugin {
+
+  private static let kLauncherBundleIdKey = "launcherBundleId"
+
+  func enable(_ command: CDVInvokedUrlCommand) {
+    sendError("Not implemented", command.callbackId);
+  }
+
+  func enableService(_ command: CDVInvokedUrlCommand) {
+    guard let launcherBundleId = command.argument(at: 0) as? String else {
+      return sendError("Must provide the launcher application's bundle ID", command.callbackId)
+    }
+    UserDefaults.standard.set(launcherBundleId, forKey: AutoStart.kLauncherBundleIdKey)
+    toggleLauncherAppOnStartupEnabled(true, launcherBundleId: launcherBundleId,
+                                      callbackId: command.callbackId)
+  }
+
+  func disable(_ command: CDVInvokedUrlCommand) {
+    guard let launcherBundleId = UserDefaults.standard.string(forKey: AutoStart.kLauncherBundleIdKey) else {
+      return sendError("Failed to retrieve the launcher application's bundle ID", command.callbackId)
+    }
+    toggleLauncherAppOnStartupEnabled(false, launcherBundleId: launcherBundleId,
+                                      callbackId: command.callbackId)
+    UserDefaults.standard.removeObject(forKey: AutoStart.kLauncherBundleIdKey)
+  }
+
+  private func toggleLauncherAppOnStartupEnabled(_ enabled: Bool, launcherBundleId: String,
+                                                 callbackId: String) {
+    NSLog("Setting login item enabled \(launcherBundleId) to \(enabled)")
+    if !SMLoginItemSetEnabled(launcherBundleId as CFString, enabled) {
+      return sendError("Failed to set login item \(launcherBundleId) to \(enabled)", callbackId)
+    }
+    sendSuccess(callbackId)
+  }
+
+  private func sendSuccess(_ callbackId: String) {
+    let result = CDVPluginResult(status: CDVCommandStatus_OK)
+    self.commandDelegate?.send(result, callbackId: callbackId)
+  }
+
+  private func sendError(_ message: String, _ callbackId: String) {
+    NSLog(message)
+    let result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: message)
+    self.commandDelegate?.send(result, callbackId: callbackId)
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,8 +12,9 @@ export interface Window {
  *
  * */
 export interface AutoStartInterface {
-    enable  ():never;
-    disable ():never;
+    enable() : never;
+    enableService(id: string) : never;
+    disable() : never;
 }
 /**
  *

--- a/www/auto-start.js
+++ b/www/auto-start.js
@@ -22,24 +22,32 @@
 var exec    = require('cordova/exec');
 
 /**
- * Activates the automatic start of your app
- * after the reboot of the device
+ * Android: activates the automatic start of your app
+ *           after the reboot of the device
+ *
+ * macOS: N/A.
  */
 exports.enable = function () {
     cordova.exec(null, null, 'AutoStart', 'enable', []);
 };
 
 /**
- * Activates the automatic start of an arbitrary (exported) service
- * after the reboot of the device
+ * Android: activates the automatic start of an arbitrary (exported) service,
+ *          with class name `id`, after the reboot of the device.
+ *
+ * macOS: enables a helper application, with bundle identifier, `id`,
+ *        to launch at boot.
  */
-exports.enableService = function (serviceClassName) {
-    cordova.exec(null, null, 'AutoStart', 'enableService', [serviceClassName]);
+exports.enableService = function (id) {
+    cordova.exec(null, null, 'AutoStart', 'enableService', [id]);
 };
 
 /**
- * Deactivates the automatic start of your app and service
- * after the reboot of the device
+ * Android: deactivates the automatic start of your app and service
+ *          after the reboot of the device
+ *
+ * macOS: disables a previously enabled helper application from launching
+ *         at boot.
  */
 exports.disable = function () {
     cordova.exec(null, null, 'AutoStart', 'disable', []);


### PR DESCRIPTION
* Adds support for starting a macOS launcher application on boot.
* Sandboxed macOS applications are not allowed to write arbitrary files, which means that they cannot register themselves as [Launch Agents](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html). Instead, Apple allows the registration of a helper application, embedded in the main app's bundle, to start on boot and launch the main app.