### PR TITLE
Added support for android@11.0.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,19 +38,19 @@
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <receiver
-                android:name="com.tonikorin.cordova.plugin.autostart.BootCompletedReceiver" android:enabled="false">
+                android:name="com.tonikorin.cordova.plugin.autostart.BootCompletedReceiver" android:enabled="false" android:exported="false">
                 <intent-filter>
                     <action android:name="android.intent.action.BOOT_COMPLETED" />
                 </intent-filter>
             </receiver>
             <receiver
-                android:name="com.tonikorin.cordova.plugin.autostart.UserPresentReceiver" android:enabled="false">
+                android:name="com.tonikorin.cordova.plugin.autostart.UserPresentReceiver" android:enabled="false" android:exported="false">
                 <intent-filter>
                     <action android:name="android.intent.action.USER_PRESENT" />
                 </intent-filter>
             </receiver>
             <receiver
-                android:name="com.tonikorin.cordova.plugin.autostart.PackageReplacedReceiver" android:enabled="true">
+                android:name="com.tonikorin.cordova.plugin.autostart.PackageReplacedReceiver" android:enabled="true" android:exported="true">
                 <intent-filter>
                     <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
                 </intent-filter>


### PR DESCRIPTION
Added support for android@11.0.0
- Fix android:exported needs to be explicitly specified for Apps targeting Android 12 and higher are required to specify