### PR TITLE
Add SYSTEM_ALERT_WINDOW permission (required for autostart on Android 10+). And fix validation.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -59,6 +59,7 @@
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+            <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
         </config-file>
 
         <source-file src="src/android/BootCompletedReceiver.java" 	target-dir="src/com/tonikorin/cordova/plugin/autostart" />

--- a/src/android/AppStarter.java
+++ b/src/android/AppStarter.java
@@ -45,8 +45,8 @@ public class AppStarter {
         }
         // Start a service in the background.
         String serviceClassName = sp.getString(AutoStart.SERVICE_CLASS_NAME, "");
-        String servicePackageName = serviceClassName.substring(0, serviceClassName.lastIndexOf("."));
         if ( !serviceClassName.equals("") ) {
+            String servicePackageName = serviceClassName.substring(0, serviceClassName.lastIndexOf("."));
             Intent serviceIntent = new Intent();
             serviceIntent.setClassName(servicePackageName, serviceClassName);
             if ( onAutostart ) {


### PR DESCRIPTION
With SYSTEM_ALERT_WINDOW permission, the app will appear on "Display over other apps" menu, and enabling this, the app will auto start on boot.

Fix: Validate serviceClassName Non-Emptiness Before Use to avoid error if serviceClassName is empty